### PR TITLE
Re-add wget

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "openpmd-viewer" %}
 {% set version = "1.0.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set sha256 = "9b73c15a3a7058a253ca667b90fdcb955144731f553d9222aebd5b82a898caae" %}
 
 package:
@@ -35,7 +35,7 @@ requirements:
     # openPMD_notebook command
     - jupyter
     # examples
-    # - wget  # noarch does not allow selectors such as no win
+    - python-wget
 
 test:
   imports:


### PR DESCRIPTION
The actual python wrapper we use for `wget` is called [python-wget on conda-forge](https://github.com/conda-forge/python-wget-feedstock).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
